### PR TITLE
fix: Fix Vercel deployment errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && xcopy public\\components dist\\components /E /I /Y && xcopy public\\css dist\\css /E /I /Y && xcopy public\\locales dist\\locales /E /I /Y",
+    "build": "vite build && node scripts/copy-static.js",
+    "build:win": "vite build && xcopy public\\components dist\\components /E /I /Y && xcopy public\\css dist\\css /E /I /Y && xcopy public\\locales dist\\locales /E /I /Y",
     "preview": "vite preview",
     "start": "vite preview --port 4173"
   },

--- a/scripts/copy-static.js
+++ b/scripts/copy-static.js
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Copy static files to dist directory for Vercel deployment
+ * Cross-platform compatible (works on Windows, Linux, macOS)
+ */
+
+function copyDir(src, dest) {
+  // Create destination directory if it doesn't exist
+  if (!fs.existsSync(dest)) {
+    fs.mkdirSync(dest, { recursive: true });
+  }
+
+  // Read source directory
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      // Recursively copy subdirectories
+      copyDir(srcPath, destPath);
+    } else {
+      // Copy files
+      fs.copyFileSync(srcPath, destPath);
+      console.log(`Copied: ${srcPath} -> ${destPath}`);
+    }
+  }
+}
+
+console.log('🚀 Copying static files to dist...');
+
+// Copy directories
+copyDir('public/components', 'dist/components');
+copyDir('public/css', 'dist/css');
+copyDir('public/locales', 'dist/locales');
+
+console.log('✅ Static files copied successfully!');

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,7 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite",
   "installCommand": "npm install",
-  "devCommand": "npm run dev",
   "rewrites": [
     {
       "source": "/locales/:lang.json",


### PR DESCRIPTION
- Remove framework: 'vite' from vercel.json to avoid conflicts
- Create cross-platform copy script (scripts/copy-static.js) for ES modules
- Update build command to use Node.js script instead of xcopy
- Ensure static files (components, css, locales) are copied to dist/
- Compatible with Vercel Linux environment